### PR TITLE
AL - Derive OAuth2 security resource ID from app.namespace

### DIFF
--- a/secrets-heroku.properties.SAMPLE
+++ b/secrets-heroku.properties.SAMPLE
@@ -3,13 +3,12 @@ app.admin.emails=phtcon@ucsb.edu
 app.member.hosted-domain=ucsb.edu
 app.google.search.apiToken=FILL-IT-IN
 
+app.slack.slashCommandToken=FILL-IT-IN
+
 auth0.domain=FILL-IT-IN
 auth0.clientId=FILL-IT-IN
 
-app.slack.slashCommandToken=FILL-IT-IN
-
-
-security.oauth2.resource.id=${app.namespace}/api
+security.oauth2.resource.id=${app.namespace}
 security.oauth2.resource.jwk.keySetUri=https://${auth0.domain}/.well-known/jwks.json
 
 spring.data.mongodb.uri=FILL-IT-IN

--- a/secrets-localhost.properties.SAMPLE
+++ b/secrets-localhost.properties.SAMPLE
@@ -8,7 +8,7 @@ app.slack.slashCommandToken=FILL-IT-IN
 auth0.domain=FILL-IT-IN
 auth0.clientId=FILL-IT-IN
 
-security.oauth2.resource.id=${app.namespace}/api
+security.oauth2.resource.id=${app.namespace}
 security.oauth2.resource.jwk.keySetUri=https://${auth0.domain}/.well-known/jwks.json
 
 spring.data.mongodb.uri=FILL-IT-IN


### PR DESCRIPTION
This PR addresses the issue of the /api/myRole endpoint not working when accessing a Heroku deployment of this app.

I don't remember why this fixes the issue, but I remember that we had to make this fix multiple times last quarter. Now that this change is in the sample file, we should hopefully not have this issue going forward.