### PR TITLE
AL - Add bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,29 @@
+---
+name: Bug Report
+about: This is a template for reporting bugs
+labels: 'bug'
+---
+
+# Bug Report
+
+<!-- Give a short description of the bug here. -->
+
+# Steps to Reproduce
+
+<!-- List the steps that you took to produce the issue, along with the OS and browser versions that you were using when you encountered the issue. -->
+
+1. 
+2. 
+3. 
+
+# Expected / Desired Behavior
+
+<!-- Describe what should have happened when you performed the steps above. -->
+
+# Observed / Actual Behavior
+
+<!-- Describe what actually happened when you performed the steps above. -->
+
+# Screenshots and Logs
+
+<!-- If you have screenshots, videos, or logs of the issue, paste them here. -->

--- a/.github/ISSUE_TEMPLATE/user-story.md
+++ b/.github/ISSUE_TEMPLATE/user-story.md
@@ -4,7 +4,6 @@ about: This is the format for defining user story issues.
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 # User Story


### PR DESCRIPTION
This PR adds an issue template for bug reports. The issue template contains the following five sections, each with a comment describing what it is supposed to include.

* Description
* Steps to Reproduce
* Expected Behavior
* Observed Behavior
* Screenshots and Logs (if any)

Additionally, the "bug" label is applied by default to all bug reports.

See [this issue](https://github.com/ucsb-cs156-w21/test-bug-report-template/issues/1) for a sample.

This PR was initially introduced in [proj-ucsb-courses-search](https://github.com/ucsb-cs156-w21/proj-ucsb-courses-search/pull/146).