### PR TITLE
6pm-2-messageTimeStamp

### DIFF
--- a/javascript/src/main/components/ChannelMessages/time.js
+++ b/javascript/src/main/components/ChannelMessages/time.js
@@ -1,7 +1,7 @@
 export default (cell, _) => {
     let date = new Date(cell * 1000);
     return date.getUTCFullYear() +
-        '-' + ('0' + date.getMonth()).slice(-2) +
+        '-' + ('0' + (date.getMonth()+1)).slice(-2) +
         '-' + ('0' + date.getDate()).slice(-2) +
         ' ' + ('0' + date.getHours()).slice(-2) +
         ':' + ('0' + date.getMinutes()).slice(-2) +

--- a/javascript/src/test/components/ChannelMessages/MessageScrollable.test.js
+++ b/javascript/src/test/components/ChannelMessages/MessageScrollable.test.js
@@ -246,4 +246,26 @@ describe("MessageScrollableView tests", () => {
         }, 500)
     });
 
+    test("Date and time render correctly", () => {
+        useSWR.mockReturnValue({
+            data: []
+        });
+        const exampleMessage = {
+            "type": "message",
+            "subtype": "channel_join",
+            "ts": "1594143066.000200",
+            "user": "U017218J9B3",
+            "text": "<!channel> This is an announcement",
+            "channel": "section-6pm",
+            "user_profile": {
+                "real_name": "Test Person"
+            }
+        }
+        const {getByText} = render(<MessageScrollableView messages={[exampleMessage]}/>);
+        setTimeout(function (){
+            const date = getByText(/2020-07-07 10:31:06/);
+            expect(date).toBeInTheDocument();
+        }, 500)
+    });
+
 });


### PR DESCRIPTION
Fix issue on channels/messages where months were off by 1 (date.getMonth() return 0-11 instead of 1-12)
I didn't write any tests for this because I couldn't find any existing tests for the date and time, and coverage seems unaffected