### PR TITLE
jl - Update jest timezone so timestamp related tests pass locally

### DIFF
--- a/javascript/jest-TZ-setup.js
+++ b/javascript/jest-TZ-setup.js
@@ -1,0 +1,3 @@
+module.exports = async () => {
+    process.env.TZ = 'UTC';
+};

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -34,6 +34,7 @@
   },
   "proxy": "http://localhost:8080",
   "jest": {
+    "globalSetup": "./jest-TZ-setup.js",
     "resetMocks": true,
     "collectCoverageFrom": [
       "src/**/*.{js,jsx,ts,tsx}",

--- a/javascript/src/test/utils/timezone.test.js
+++ b/javascript/src/test/utils/timezone.test.js
@@ -1,6 +1,6 @@
 describe('Jest Timezone', () => {
     it('should always be UTC', () => {
-        // Because GitHub actions runs in UTC due to the slack API, changing jest to run in same timezone
+        // Because GitHub actions runs in UTC due to the slack API, changing jest to run in same timezone so that locally tests will pass
         expect(new Date().getTimezoneOffset()).toBe(0);
     });
   });

--- a/javascript/src/test/utils/timezone.test.js
+++ b/javascript/src/test/utils/timezone.test.js
@@ -1,0 +1,6 @@
+describe('Jest Timezone', () => {
+    it('should always be UTC', () => {
+        // Because GitHub actions runs in UTC due to the slack API, changing jest to run in same timezone
+        expect(new Date().getTimezoneOffset()).toBe(0);
+    });
+  });


### PR DESCRIPTION
This PR addresses the issue in #183 where tests related to timestamps on slack messages will fail locally because jest uses the user's machine time but GitHub will use UTC time.

Will still render in the browser according to the user's time zone in the UI. You can check from the deployment