### PR TITLE
kw - footer links open a new tab instead

### DIFF
--- a/javascript/src/main/components/Footer/AppFooter.js
+++ b/javascript/src/main/components/Footer/AppFooter.js
@@ -4,15 +4,15 @@ const AppFooter = () => {
   return (
     <footer className="bg-light p-3 text-center">
       This app is a class project of {" "}
-      <a href="https://ucsb-cs156.github.io">
+      <a href="https://ucsb-cs156.github.io" target = "_blank">
         CMPSC 156 
         </a> 
       {" "} at {" "}
-      <a href="https://ucsb.edu">
+      <a href="https://ucsb.edu" target = "_blank">
         UCSB
       </a>
       . Check out the source code on {" "}
-      <a href="https://github.com/ucsb-cs156-w21/proj-mapache-search">
+      <a href="https://github.com/ucsb-cs156-w21/proj-mapache-search" target = "_blank">
         GitHub
       </a>
       !


### PR DESCRIPTION
The footer links should open a new tab for the class, school, and GitHub instead of making the user leave the app.